### PR TITLE
feat: t4 - chapter2-l2-t4-files-no-extensions.sh

### DIFF
--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -29,7 +29,13 @@ find "$1" -type f | while read file; do
   # check files that contain more than one dot in the name
   elif
     [[ $(echo "$file" | grep -o "\." | wc -l) > 1 ]]; then
-        echo "${file%.*}"
+      file_path=$(dirname "$file")
+      file_name="${file##*/}"
+      if [[ $(echo "$file_name" | grep -o "\." | wc -l) -eq 1 ]]; then
+        echo "${file_path}/${file_name}"
+      else
+        echo "${file_path}/${file_name%%.*}"
+      fi
   fi
 
 done

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Script get a folder as an argument and return all files (including in the nested directories) but without the extension
+
 # checking for the number of passed arguments
 if [[ $# -ne 1 ]]; then
   echo "You must specify one folder"
@@ -7,11 +9,27 @@ if [[ $# -ne 1 ]]; then
 fi
 
 # search folder contents, output content without extension
-find "$1" -depth -type f | while read file; do
-  if [[ $(echo "$file" | grep -o "\." | wc -l) -eq 1 && "${file##*/}" == .* ]]; then
-    echo "$file"
-  else
-    echo "${file%.*}"
+find "$1" -type f | while read file; do
+
+  # check files that contain only one dot in the name
+  if [[ $(echo "$file" | grep -o "\." | wc -l) -eq 1 ]]; then
+
+    # if the file is hidden, then display the file name
+    if [[ "${file}" == *"/."* ]]; then
+      echo "${file}"
+    else
+      echo "${file%.*}"
+    fi
+
+  # check files that contain zero dots in the name
+  elif
+    [[ $(echo "$file" | grep -o "\." | wc -l) -eq 0 ]]; then
+      echo "$file"
+
+  # check files that contain more than one dot in the name
+  elif
+    [[ $(echo "$file" | grep -o "\." | wc -l) > 1 ]]; then
+        echo "${file%.*}"
   fi
 
 done

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
+
 #checking for the number of passed arguments
 if [[ $# -ne 1 ]]; then
   echo "You must specify one folder"
   exit 1
 fi
-#search folder contents, output content without extensionsearch folder contents, output content without extension
+
+#search folder contents, output content without extension
 find "$1" -type f | while read file; do
-  echo ${file/.*/ }
+  echo "${file/.*/ }"
 done
+

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -9,12 +9,12 @@ if [[ $# -ne 1 ]]; then
 fi
 
 # search folder contents, output content without extension
-find "$1" -type f | while read file; do
+find "$1" -type f | while read -r file; do
 
   # check files that contain only one dot in the name
   if [[ $(echo "$file" | grep -o "\." | wc -l) -eq 1 ]]; then
 
-    # if the file is hidden, then display the file name
+    # if the file is dotfile
     if [[ "${file}" == *"/."* ]]; then
       echo "${file}"
     else
@@ -22,13 +22,11 @@ find "$1" -type f | while read file; do
     fi
 
   # check files that contain zero dots in the name
-  elif
-    [[ $(echo "$file" | grep -o "\." | wc -l) -eq 0 ]]; then
+  elif [[ $(echo "$file" | grep -o "\." | wc -l) -eq 0 ]]; then
       echo "$file"
 
   # check files that contain more than one dot in the name
-  elif
-    [[ $(echo "$file" | grep -o "\." | wc -l) > 1 ]]; then
+  elif [[ $(echo "$file" | grep -o "\." | wc -l) > 1 ]]; then
       file_path=$(dirname "$file")
       file_name="${file##*/}"
       if [[ $(echo "$file_name" | grep -o "\." | wc -l) -eq 1 ]]; then

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -14,7 +14,7 @@ find "$1" -type f | while read -r file; do
   # check files that contain only one dot in the name
   if [[ $(echo "$file" | grep -o "\." | wc -l) -eq 1 ]]; then
 
-    # if the file is dotfile
+    # if the file is hidden, then display the file name
     if [[ "${file}" == *"/."* ]]; then
       echo "${file}"
     else
@@ -22,17 +22,27 @@ find "$1" -type f | while read -r file; do
     fi
 
   # check files that contain zero dots in the name
-  elif [[ $(echo "$file" | grep -o "\." | wc -l) -eq 0 ]]; then
+  elif
+    [[ $(echo "$file" | grep -o "\." | wc -l) -eq 0 ]]; then
       echo "$file"
 
   # check files that contain more than one dot in the name
-  elif [[ $(echo "$file" | grep -o "\." | wc -l) > 1 ]]; then
+  elif
+    [[ $(echo "$file" | grep -o "\." | wc -l) > 1 ]]; then
       file_path=$(dirname "$file")
       file_name="${file##*/}"
-      if [[ $(echo "$file_name" | grep -o "\." | wc -l) -eq 1 ]]; then
-        echo "${file_path}/${file_name}"
-      else
+
+      # remove the extension if the file name: contains more than 1 dot
+      # OR the file is not hidden and has the extension
+      if [[ ($(echo "$file_name" | grep -o "\." | wc -l) -ne 1) || \
+            ($(echo "$file_name" | grep -o "\." | wc -l) -eq 1) && ! ("${file_name:0:1}" == ".") ]]; then
         echo "${file_path}/${file_name%%.*}"
+
+      # output the file name unchanged if the file does not contain dots
+      # OR it is a hidden file
+      elif [[ ($(echo "$file_name" | grep -o "\." | wc -l) -eq 0) || \
+              ($(echo "$file_name" | grep -o "\." | wc -l) -eq 1) && ("${file_name:0:1}" == ".") ]]; then
+        echo "${file_path}/${file_name}"
       fi
   fi
 

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Script get a folder as an argument and return all files (including in the nested directories) but without the extension
+# Script get a folder as an argument and return all files (including in the nested directories) but without the ext>
 
 # checking for the number of passed arguments
 if [[ $# -ne 1 ]]; then
@@ -11,8 +11,10 @@ fi
 # search folder contents, output content without extension
 find "$1" -type f | while read -r file; do
 
+  file_num_dots=$(echo "$file" | grep -o "\." | wc -l)
+
   # check files that contain only one dot in the name
-  if [[ $(echo "$file" | grep -o "\." | wc -l) -eq 1 ]]; then
+  if [[ "$file_num_dots" -eq 1 ]]; then
 
     # if the file is hidden, then display the file name
     if [[ "${file}" == *"/."* ]]; then
@@ -23,25 +25,27 @@ find "$1" -type f | while read -r file; do
 
   # check files that contain zero dots in the name
   elif
-    [[ $(echo "$file" | grep -o "\." | wc -l) -eq 0 ]]; then
+    [[ "$file_num_dots" -eq 0 ]]; then
       echo "$file"
 
   # check files that contain more than one dot in the name
   elif
-    [[ $(echo "$file" | grep -o "\." | wc -l) > 1 ]]; then
+    [[ "$file_num_dots" > 1 ]]; then
       file_path=$(dirname "$file")
       file_name="${file##*/}"
 
       # remove the extension if the file name: contains more than 1 dot
       # OR the file is not hidden and has the extension
-      if [[ ($(echo "$file_name" | grep -o "\." | wc -l) -ne 1) || \
-            ($(echo "$file_name" | grep -o "\." | wc -l) -eq 1) && ! ("${file_name:0:1}" == ".") ]]; then
+      file_name_num_dots=$(echo "$file_name" | grep -o "\." | wc -l)
+
+      if [[ ("$file_name_num_dots" -ne 1) || \
+            ("$file_name_num_dots" -eq 1) && ! ("${file_name:0:1}" == ".") ]]; then
         echo "${file_path}/${file_name%%.*}"
 
       # output the file name unchanged if the file does not contain dots
       # OR it is a hidden file
-      elif [[ ($(echo "$file_name" | grep -o "\." | wc -l) -eq 0) || \
-              ($(echo "$file_name" | grep -o "\." | wc -l) -eq 1) && ("${file_name:0:1}" == ".") ]]; then
+      elif [[ ("$file_num_dots" -eq 0) || \
+              ("$file_num_dots" -eq 1) && ("${file_name:0:1}" == ".") ]]; then
         echo "${file_path}/${file_name}"
       fi
   fi

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#checking for the number of passed arguments
+if [[ $# -ne 1 ]]; then
+  echo "You must specify one folder"
+  exit 1
+fi
+#search folder contents, output content without extensionsearch folder contents, output content without extension
+find "$1" -type f | while read file; do
+  echo ${file/.*/ }
+done

--- a/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
+++ b/chapter2/tests/t4/chapter2-l2-t4-files-no-extensions.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
-#checking for the number of passed arguments
+# checking for the number of passed arguments
 if [[ $# -ne 1 ]]; then
   echo "You must specify one folder"
   exit 1
 fi
 
-#search folder contents, output content without extension
-find "$1" -type f | while read file; do
-  echo "${file/.*/ }"
-done
+# search folder contents, output content without extension
+find "$1" -depth -type f | while read file; do
+  if [[ $(echo "$file" | grep -o "\." | wc -l) -eq 1 && "${file##*/}" == .* ]]; then
+    echo "$file"
+  else
+    echo "${file%.*}"
+  fi
 
+done


### PR DESCRIPTION
**Summary
Test Task**

Script should get a folder as an argument and return all files (including in the nested directories) but without the extension

**name the file**: `chapter2-l2-t4-files-no-extensions.sh`

**example of the call:**

./chapter2-l2-t4-files-no-extensions.sh ~/tmp/bazel

```
/tmp/bazel/tools/objc/dummy
/tmp/bazel/third_party/zlib/zutil
/tmp/bazel/third_party/zlib/uncompr
/tmp/bazel/third_party/zlib/trees
/tmp/bazel/third_party/zlib/test/minigzip
/tmp/bazel/third_party/zlib/test/infcover
/tmp/bazel/third_party/zlib/test/example
/tmp/bazel/third_party/zlib/inftrees

```

**my results**
`./chapter2-l2-t4-files-no-extensions.sh ~/Загрузки/a`
**output:**
`repos/iss-kubernetes-aws-deploy-key
repos/kustomization
repos/iss-kubernetes-aws-deploy-key
repos/iss-backend-deploy-key
repos/iss-frontend-deploy-key
repos/iss-backend-deploy-key
repos/iss-frontend-deploy-key
`
