### PR TITLE
feat: t7 - chapter2-l2-t7-get-unique-files.sh

### DIFF
--- a/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
+++ b/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
@@ -8,15 +8,10 @@ if [[ $# -ne 1 ]]; then
   exit 1
 fi
 
-var=$1
+folder=$1
 
-# create an array
-file_name=()
-
-# return a list of all unique files with extensions without the absolute path
-find "$var" -type f | while read -r file; do
-  if [[ ! "${file_name[@]}" =~ "${file##*/}" ]]; then
-    file_name+="${file##*/}"
-    echo "${file##*/}"
-  fi
-done
+# all unique files with extensions without the absolute path
+find "$folder" -type f | while read -r file; do
+  file_name="${file##*/}"
+  echo "${file_name}"
+done | sort -u

--- a/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
+++ b/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#Checking the number of arguments passed
+if [[ $# -ne 1 ]]; then
+  echo "You must specify one folder"
+  exit 1
+fi
+#create an array
+arr=()
+#return a list of all unique files with extensions without the absolute path
+for file in $(find $1 -type f); do
+  if [[ ! "${arr[@]}" =~ ${file##*/} ]]; then
+    arr+=${file##*/}
+    echo ${file##*/}
+  fi
+done

--- a/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
+++ b/chapter2/tests/t7/chapter2-l2-t7-get-unique-files.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
-#Checking the number of arguments passed
+
+# getting a list of all unique files with extensions but no absolute path
+
+# сhecking the number of arguments passed
 if [[ $# -ne 1 ]]; then
   echo "You must specify one folder"
   exit 1
 fi
-#create an array
-arr=()
-#return a list of all unique files with extensions without the absolute path
-for file in $(find $1 -type f); do
-  if [[ ! "${arr[@]}" =~ ${file##*/} ]]; then
-    arr+=${file##*/}
-    echo ${file##*/}
+
+var=$1
+
+# create an array
+file_name=()
+
+# return a list of all unique files with extensions without the absolute path
+find "$var" -type f | while read -r file; do
+  if [[ ! "${file_name[@]}" =~ "${file##*/}" ]]; then
+    file_name+="${file##*/}"
+    echo "${file##*/}"
   fi
 done


### PR DESCRIPTION
**Summary**
**Test task**
t7 - get only the filenames
Script should get a folder as an argument and return a list of all unique files with extensions but without the absolute path (including in the nested directories). only -f option is allowed for the use of find command, i.e.: find /tmp -type f. Which should find all files in all nested dirs and then process the output by using expansion.

name the file: `chapter2-l2-t7-get-unique-files.sh`

example of the call:

`chapter2-l2-t7-get-unique-files.sh /tmp/bazel`
```

main.sh.x.c
main.c
dummy.c
zutil.c
uncompr.c
trees.c
minigzip.c
infcover.c
example.c
inftrees.c
```
**my result**
`./chapter2-l2-t7-get-unique-files.sh ~/Загрузки/a `
**output**
```
photo_2023-03-20_16-00-58.jpg
Maven_spring_demo.zip
ideaIU-2022.3.3.tar.gz
google-chrome-stable_current_amd64.deb
dariyanalimova.p12
```
