### PR TITLE
feat: t3 - chapter2-t3-velero-eks-diff.sh file

### DIFF
--- a/chapter2/tests/t3/chapter2-t3-velero-eks-diff.sh
+++ b/chapter2/tests/t3/chapter2-t3-velero-eks-diff.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# list of kubernetes namespaces that are not backed up
-
 # function to check if a file was loaded or not
 function check_file() {
   local uri=$1
@@ -13,20 +11,24 @@ function check_file() {
 }
 
 # download velero backup
-VELERO_BACKUP_NAMESPACES=$(curl -sSL https://gist.github.com/dmitry-mightydevops/016139747b6cefdc94160607f95ede74/raw/velero.yaml)
+VELERO_BACKUP=$(curl -sSL https://gist.github.com/dmitry-mightydevops/016139747b6cefdc94160607f95ede74/raw/velero.yaml)
 
-check_file "velero.yaml" "${VELERO_BACKUP_NAMESPACES}"
+check_file "velero.yaml" "${VELERO_BACKUP}"
 
 # list of kubernetes namespaces backed up
-VELERO_NAMESPACES=$(echo "$VELERO_BACKUP_NAMESPACES" | yq ".spec.source.helm.values" \
+VELERO_NAMESPACES=$(echo "$VELERO_BACKUP" | yq ".spec.source.helm.values" \
   | yq ".schedules[].template.includedNamespaces[]" | sort )
 
 # list of actual kubernetes namespaces
 KUBERNETES_NAMESPACES=$(curl -sSL https://gist.github.com/dmitry-mightydevops/297c4e235b61982f21a0bbbf7319ac24/raw/kubernetes-namespaces.txt)
 
+# check if kubernetes-namespaces.txt file exists
+if [[ ! -f "kubernetes-namespaces.txt" ]]; then
+  echo "ERROR: kubernetes-namespaces.txt file not found"
+  exit 1
+fi
+
 check_file "kubernetes-namespaces.txt" "KUBERNETES_NAMESPACES"
 
 # list of kubernetes namespaces that are not backed up
-echo "$VELERO_NAMESPACES" > combined.txt
-echo "$KUBERNETES_NAMESPACES" >> combined.txt
-sort combined.txt | uniq -u
+(sort <<< "$VELERO_NAMESPACES"$'\n'"$KUBERNETES_NAMESPACES" | uniq -u)

--- a/chapter2/tests/t3/chapter2-t3-velero-eks-diff.sh
+++ b/chapter2/tests/t3/chapter2-t3-velero-eks-diff.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# list of kubernetes namespaces that are not backed up
+
+# download velero backup
+VELERO_BACKUP_URL=$(curl -sSL https://gist.github.com/dmitry-mightydevops/016139747b6cefdc94160607f95ede74/raw/velero.yaml)
+
+# list of kubernetes namespaces backed up
+ARR_BACKUP=($(echo "$VELERO_BACKUP_URL" | yq eval '.spec.source.helm.values' | yq eval '.schedules.system.template.includedNamespaces[]'))
+
+# download kubernetes namespaces
+ARR_NAMESPACES=($(curl -sSL https://gist.github.com/dmitry-mightydevops/297c4e235b61982f21a0bbbf7319ac24/raw/kubernetes-namespaces.txt))
+
+# list of kubernetes namespaces that are not backed up
+for str in "${ARR_NAMESPACES[@]}"; do
+  if ! [[ "${ARR_BACKUP[@]}" =~ "$str" ]] ; then
+    echo "$str"
+  fi
+done

--- a/chapter2/tests/t3/chapter2-t3-velero-eks-diff.sh
+++ b/chapter2/tests/t3/chapter2-t3-velero-eks-diff.sh
@@ -2,10 +2,10 @@
 
 # function to check if a file was loaded or not
 function check_file() {
-  local uri=$1
+  local name_file=$1
   local file=$2
   if [[ "$file" == *"404:"* ]]; then
-    echo "ERROR: file not found at $uri"
+    echo "ERROR: file $name_file not found "
     exit 1
   fi
 }
@@ -22,13 +22,7 @@ VELERO_NAMESPACES=$(echo "$VELERO_BACKUP" | yq ".spec.source.helm.values" \
 # list of actual kubernetes namespaces
 KUBERNETES_NAMESPACES=$(curl -sSL https://gist.github.com/dmitry-mightydevops/297c4e235b61982f21a0bbbf7319ac24/raw/kubernetes-namespaces.txt)
 
-# check if kubernetes-namespaces.txt file exists
-if [[ ! -f "kubernetes-namespaces.txt" ]]; then
-  echo "ERROR: kubernetes-namespaces.txt file not found"
-  exit 1
-fi
-
-check_file "kubernetes-namespaces.txt" "KUBERNETES_NAMESPACES"
+check_file "kubernetes-namespaces.txt" "${KUBERNETES_NAMESPACES}"
 
 # list of kubernetes namespaces that are not backed up
-(sort <<< "$VELERO_NAMESPACES"$'\n'"$KUBERNETES_NAMESPACES" | uniq -u)
+sort <<< "$VELERO_NAMESPACES"$'\n'"$KUBERNETES_NAMESPACES" | uniq -u


### PR DESCRIPTION
**Summary
Test Task
T3 - Find namespaces without the backup**
We need to come up with a prototype solution that will give us the list of kubernetes namespaces we haven't backed up. We have a special backup manifest that contains the configurationf for the backups.

**For example:** https://gist.github.com/dmitry-mightydevops/016139747b6cefdc94160607f95ede74

the configuration is in the schedules.[].includedNamespaces block of the file

   ```
     schedules:
          system:
            labels:
              backup: system
            schedule: "@every 24h"
            template:
              ttl: "480h"
              includedNamespaces:
                - cert-manager
                - ingress-nginx
                - kube-node-lease
                - kube-public
                - kube-system
                - ops
                - opsgenie
                - default
              excludedResources:
                - orders.acme.cert-manager.io
                - challenges.acme.cert-manager.io
                - certificaterequests.cert-manager.io
          a3fs:
            labels:
              backup: a3fs
            schedule: "@every 24h"
            template:
              ttl: "480h"
              includedNamespaces:
                - a3fs
```
we're supposed to run the following command:

`➜ kubectl get ns -o="custom-columns=NAME:.metadata.name" --no-headers`

that will give us a list of all namespaces in the kubernetes cluster.

The result of this command is https://gist.github.com/dmitry-mightydevops/297c4e235b61982f21a0bbbf7319ac24

Implement the bash script that will find all namespaces in the cluster that has not been configured in the velero manifest. I.e. operation on sets.

**name the file:** chapter2-t3-velero-eks-diff.sh
**example of the call:**
```
./chapter2-t3-velero-eks-diff.sh
```
**example output:**
```
- aacct
- aaoa-ari-cleara
- arthrexvip
- axia
- camp-dotnet
- camp-python
- camp-unity
- caregiver
- ci-experiments
- ci-experiments-apps
...all namespaces should be listed that are not configured for the backup
```

**nuances:**

- your bash script should download these 2 gists using curl and pass them into stdout of other commands you're using.
- you can use any CLI tool from the distro you're using to calculate the diff between two data blocks and come up with the output above.
- you can use yq or jq cli if necessary for your ops.

**my results:**
`./chapter2-t3-velero-eks-diff.sh`
**output:**
`aacct
aaoa-ari-cleara
arthrexvip
axia
camp-dotnet
camp-python
camp-unity
caregiver
ci-experiments
ci-experiments-apps
commlrning
debug
demo
dev
disvr
dogvr
enrgy
fallon-medica
faroeve
fbmm
firearm
github-inactivity
igntpb
inkus
insights-agent
interesnee
jenkins
kubewatch
macroplate
mailhog
maunf
medvr
metrics-server
nrs
oprs
prfctpt
redis
rma
saritasa-android
saritasa-ios
saritasa-jira-qa-tool
saritasa-php
saritasa-python
saritasa-qa
saritasa-unity
scripta
sgvr
sportsthread
streetparking
tekton-pipelines-experiments
toro
tran
trapi
trivver
utd
utils
velero
vrcatchup
`