### PR TITLE
feat: t10 - chapter3-t10-nginx.conf file

### DIFF
--- a/chapter3/tests/t10/nginx.conf
+++ b/chapter3/tests/t10/nginx.conf
@@ -1,0 +1,92 @@
+user nginx;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+        worker_connections 768;
+}
+
+http {
+        log_format json escape=json '{ "@timestamp": "$time_iso8601", '
+               '"remote_addr": "$remote_addr", '
+               '"body_bytes_sent": "$body_bytes_sent", '
+               '"status": $status, '
+               '"request": "$request", '
+               '"url": "$uri", '
+               '"request_method": "$request_method", '
+               '"http_referrer": "$http_referer", '
+               '"http_user_agent": "$http_user_agent" }';
+
+
+        sendfile on;
+        tcp_nopush on;
+        types_hash_max_size 2048;
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
+
+        ##
+        # Logging Settings
+        ##
+
+        access_log /var/log/nginx/access.log;
+        error_log /var/log/nginx/error.log;
+
+        include /etc/nginx/conf.d/*.conf;
+        include /etc/nginx/sites-enabled/*;
+
+
+        server {
+                listen 80;
+                listen [::]:80;
+
+                listen 443 ssl http2;
+                listen [::]:443 ssl http2;
+                ssl_certificate /tmp/camp-php.local.pem;
+                ssl_certificate_key /tmp/camp-php.local-key.pem;
+
+                root /var/www/camp-php.local;
+
+                index index.html index.htm index.nginx-debian.html;
+
+                server_name camp-php.local;
+
+                location = /hello {
+                        add_header Content-Type text/plain;
+                        return 200 $args;
+                }
+
+                location / {
+                        try_files $uri $uri/ =404;
+                }
+                access_log /var/log/nginx/camp-php.local_access.log json;
+        }
+
+        server {
+                listen 80;
+                listen [::]:80 ;
+
+                listen 443 ssl http2;
+                listen [::]:443 ssl http2;
+                ssl_certificate /tmp/camp-pyton.local.pem;
+                ssl_certificate_key /tmp/camp-pyton.local-key.pem;
+
+                root /var/www/camp-pyton.local;
+
+
+                index index.html index.htm index.nginx-debian.html;
+
+                server_name camp-pyton.local;
+
+                location = /hello {
+                        add_header Content-Type text/plain;
+                        return 200 $args;
+                }
+
+                location / {
+                        try_files $uri $uri/ =404;
+                }
+
+                access_log /var/log/nginx/camp-pyton.local_access.log json;
+        }
+}

--- a/chapter3/tests/t10/nginx.conf
+++ b/chapter3/tests/t10/nginx.conf
@@ -1,92 +1,82 @@
 user nginx;
 worker_processes auto;
 pid /run/nginx.pid;
-include /etc/nginx/modules-enabled/*.conf;
 
 events {
-        worker_connections 768;
+	worker_connections 768;
 }
 
 http {
-        log_format json escape=json '{ "@timestamp": "$time_iso8601", '
-               '"remote_addr": "$remote_addr", '
-               '"body_bytes_sent": "$body_bytes_sent", '
-               '"status": $status, '
-               '"request": "$request", '
-               '"url": "$uri", '
-               '"request_method": "$request_method", '
-               '"http_referrer": "$http_referer", '
-               '"http_user_agent": "$http_user_agent" }';
+	index index.html;
 
+	log_format json escape=json '{
+		"@timestamp": "$time_iso8601", '
+		'"remote_addr": "$remote_addr", '
+		'"body_bytes_sent": "$body_bytes_sent", '
+		'"status": $status, '
+		'"request": "$request", '
+		'"url": "$uri", '
+		'"request_method": "$request_method", '
+		'"http_referrer": "$http_referer", '
+		'"http_user_agent": "$http_user_agent"
+	}';
 
-        sendfile on;
-        tcp_nopush on;
-        types_hash_max_size 2048;
-        include /etc/nginx/mime.types;
-        default_type application/octet-stream;
+	sendfile on;
+	tcp_nopush on;
+	types_hash_max_size 2048;
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
 
-        ##
-        # Logging Settings
-        ##
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
 
-        access_log /var/log/nginx/access.log;
-        error_log /var/log/nginx/error.log;
+	server {
 
-        include /etc/nginx/conf.d/*.conf;
-        include /etc/nginx/sites-enabled/*;
+		listen 443 ssl http2;
+		listen [::]:443 ssl http2;
+		ssl_certificate /tmp/camp-php.local.pem;
+		ssl_certificate_key /tmp/camp-php.local-key.pem;
 
+		root /var/www/camp-php.local;
 
-        server {
-                listen 80;
-                listen [::]:80;
+		index index.html index.htm index.nginx-debian.html;
 
-                listen 443 ssl http2;
-                listen [::]:443 ssl http2;
-                ssl_certificate /tmp/camp-php.local.pem;
-                ssl_certificate_key /tmp/camp-php.local-key.pem;
+		server_name camp-php.local;
 
-                root /var/www/camp-php.local;
+		access_log /var/log/nginx/camp-php.local_access.log json;
 
-                index index.html index.htm index.nginx-debian.html;
+		location = /hello {
+			add_header Content-Type text/plain;
+			return 200 $args;
+		}
 
-                server_name camp-php.local;
+		location / {
+			try_files $uri $uri/ =404;
+		}
+	}
 
-                location = /hello {
-                        add_header Content-Type text/plain;
-                        return 200 $args;
-                }
+	server {
 
-                location / {
-                        try_files $uri $uri/ =404;
-                }
-                access_log /var/log/nginx/camp-php.local_access.log json;
-        }
+		listen 443 ssl http2;
+		listen [::]:443 ssl http2;
+		ssl_certificate /tmp/camp-pyton.local.pem;
+		ssl_certificate_key /tmp/camp-pyton.local-key.pem;
 
-        server {
-                listen 80;
-                listen [::]:80 ;
+		root /var/www/camp-pyton.local;
 
-                listen 443 ssl http2;
-                listen [::]:443 ssl http2;
-                ssl_certificate /tmp/camp-pyton.local.pem;
-                ssl_certificate_key /tmp/camp-pyton.local-key.pem;
+		index index.html index.htm index.nginx-debian.html;
 
-                root /var/www/camp-pyton.local;
+		server_name camp-pyton.local;
 
+		access_log /var/log/nginx/camp-pyton.local_access.log json;
 
-                index index.html index.htm index.nginx-debian.html;
+		location = /hello {
+			add_header Content-Type text/plain;
+			return 200 $args;
+		}
 
-                server_name camp-pyton.local;
-
-                location = /hello {
-                        add_header Content-Type text/plain;
-                        return 200 $args;
-                }
-
-                location / {
-                        try_files $uri $uri/ =404;
-                }
-
-                access_log /var/log/nginx/camp-pyton.local_access.log json;
-        }
+		location / {
+			try_files $uri $uri/ =404;
+		}
+	}
 }


### PR DESCRIPTION
# Summary
## Test Task

**implement your test host**

- setup nginx supporting 2 servers
- camp-php.local (this will be used for future php experiments)
- camp-python.local (this will be used for future python experiments)
- both servers should support named certificates for the domains mentioned above. use mkcert cli to do that
- both server should implement custom location /hello, that will return 200 OK status code along with the value of the query_string passed into that URL, [see here](https://www.techopedia.com/definition/1228/query-string), for example https://camp-php.local/hello?tech_stack=php, which should output the entire query_string
- your SSL cert should be valid in CURL call in CLI, as well as if you open it in the browser
- your camp-php.local server should output logs in JSON format
- open PR when you done, in the PR - pls demonstrate the output of the curl call for the URL in each domain, and the screenshot in the browser

`curl -I https://camp-php.local`
```
HTTP/2 200 
server: nginx/1.22.0 (Ubuntu)
date: Sat, 15 Apr 2023 08:04:03 GMT
content-type: text/html
content-length: 246
last-modified: Mon, 10 Apr 2023 14:03:03 GMT
etag: "64341717-f6"
accept-ranges: bytes
```
## my results
` curl -I https://camp-pyton.local`
```
HTTP/2 200 
server: nginx/1.22.0 (Ubuntu)
date: Sat, 15 Apr 2023 08:04:10 GMT
content-type: text/html
content-length: 250
last-modified: Mon, 10 Apr 2023 15:39:15 GMT
etag: "64342da3-fa"
accept-ranges: bytes
```
![Screenshot_20230415_120812](https://user-images.githubusercontent.com/117597862/232199138-59ea3561-61f6-46d7-a160-7a86956f49e5.png)

