### PR TITLE
feat: t14 - chapter4-t14-compile distroless python3 OOM container

### DIFF
--- a/chapter4/tests/t14/.pre-commit-config.yaml
+++ b/chapter4/tests/t14/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/hadolint/hadolint
+    rev: v2.7.0
+    hooks:
+    -   id: hadolint

--- a/chapter4/tests/t14/Dockerfile
+++ b/chapter4/tests/t14/Dockerfile
@@ -5,7 +5,7 @@ COPY . /app
 RUN pip install --no-cache-dir -r requirements.txt
 
 #Deploy
-FROM gcr.io/distroless/python3:3.
+FROM gcr.io/distroless/python3:nonroot
 WORKDIR /app
 COPY --from=build-env /app /app
 COPY --from=build-env /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages

--- a/chapter4/tests/t14/Dockerfile
+++ b/chapter4/tests/t14/Dockerfile
@@ -1,0 +1,13 @@
+# Compile
+FROM python:3-slim AS build-env
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Deploy
+FROM gcr.io/distroless/python3:debug
+WORKDIR /app
+COPY --from=build-env /app /app
+COPY --from=build-env /usr/local/ /usr/local
+
+ENTRYPOINT [ "python", "memory.py" ]

--- a/chapter4/tests/t14/Dockerfile
+++ b/chapter4/tests/t14/Dockerfile
@@ -4,10 +4,10 @@ WORKDIR /app
 COPY . /app
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Deploy
-FROM gcr.io/distroless/python3:debug
+#Deploy
+FROM gcr.io/distroless/python3:3.
 WORKDIR /app
 COPY --from=build-env /app /app
-COPY --from=build-env /usr/local/ /usr/local
-
+COPY --from=build-env /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+ENV PYTHONPATH=/usr/local/lib/python3.11/site-packages
 ENTRYPOINT [ "python", "memory.py" ]

--- a/chapter4/tests/t14/Makefile
+++ b/chapter4/tests/t14/Makefile
@@ -1,12 +1,14 @@
-memory_limit=100m
+memory_limit = 100m
 docker_image = memory
+docker_container = memory_container
 
 build:
-	docker build -t $(docker_image) .
+        docker build -t $(docker_image) .
 
 run:
-	@if [ -z "$(memory_limit)" ]; then \
-		docker run --rm  $(docker_image); \
-	else \
-		docker run -m $(memory_limit) $(docker_image) || docker inspect -f '{{.State}}' $$(docker ps -lq); \
-	fi
+        @if [ -z "$(memory_limit)" ]; then \
+                docker run --rm $(docker_image); \
+        else \
+                docker run --name $(docker_container) -m $(memory_limit) $(docker_image) || \
+                docker inspect -f '{{.State}}' $(docker_container) && docker rm $(docker_container) ; \
+        fi

--- a/chapter4/tests/t14/Makefile
+++ b/chapter4/tests/t14/Makefile
@@ -1,0 +1,12 @@
+memory_limit=100m
+docker_image = memory
+
+build:
+	docker build -t $(docker_image) .
+
+run:
+	@if [ -z "$(memory_limit)" ]; then \
+		docker run --rm  $(docker_image); \
+	else \
+		docker run -m $(memory_limit) $(docker_image) || docker inspect -f '{{.State}}' $$(docker ps -lq); \
+	fi

--- a/chapter4/tests/t14/README.md
+++ b/chapter4/tests/t14/README.md
@@ -1,0 +1,3 @@
+hadolint Dockerfile
+pre-commit install
+

--- a/chapter4/tests/t14/memory.py
+++ b/chapter4/tests/t14/memory.py
@@ -1,0 +1,10 @@
+import array
+from memory_profiler import memory_usage
+
+def allocate(size):
+    some_var = array.array('l', range(size))
+
+usage = memory_usage((allocate, (int(1e7),)))
+peak = max(usage)
+print(f"Usage over time: {usage}")
+print(f"Peak usage: {peak}")

--- a/chapter4/tests/t14/requirements.txt
+++ b/chapter4/tests/t14/requirements.txt
@@ -1,0 +1,1 @@
+memory_profiler


### PR DESCRIPTION
# Summary
## Test task
**compile distroless python3 OOM container**

Compile container using distroless base python3 image
<https://github.com/GoogleContainerTools/distroless>

See python files in **testtask** folder.

What you will need to do:

- setup pre-commit in the folder to run <https://github.com/hadolint/hadolint> checks against any Dockerfiles
  - don't open any PR if your Dockerfile does not pass validation from the linter.
- provide README.md with instructions how to run/test your work
- create Makefile with the following targets:
  - `build`
  - `run`
    - `run` target should accept parameter `limit` that will set the desired max memory limit for the running docker container
    - if such parameter is not set, a default value of **100m** should be used
- `make run` should start the docker container and output content similar to 
  ```sh
  Usage over time: [20.67578125, 20.67578125, 35.30078125, 50.17578125, 64.80078125, 79.55078125, 94.30078125, 20.734375]
  Peak usage: 94.30078125
  ```
- `make run` with optional argument for memory set at **30m** should understand that container exited by error and in this case output the following line
  ```sh
  {exited false false false true false 0 137  2023-04-17T00:50:11.053754525Z 2023-04-17T00:50:13.721847306Z <nil>}
  ```
  which is content of the docker **State** value.
  
 ## my results
`make run `

**output**:
```                
Usage over time: [21.9375, 22.0390625, 24.859375, 27.453125, 30.2890625, 33.03125, 36.3828125, 39.4765625, 42.4609375, 45.8125, 49.1640625, 53.03125, 56.640625, 60.42578125, 63.06640625, 66.93359375, 70.80078125, 74.92578125, 78.79296875, 82.91796875, 86.51953125, 90.64453125, 95.02734375, 21.95703125]
Peak usage: 95.02734375

```
## my results

`make run memory_limit=30M `
**output**:
```
{exited false false false true false 0 137  2023-04-25T18:41:59.356324616Z 2023-04-25T18:42:01.172699558Z <nil>}

```
  