### PR TITLE
feat: t9 - chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh file

### DIFF
--- a/chapter2/tests/t9/chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh
+++ b/chapter2/tests/t9/chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+ports=()
+first_port=10000
+last_port=10100
+time_sleep=20
+
+# TCP connections in the port range 10000-10100
+while (true); do
+
+  connections=$(ss -ltn -at "( sport >= "${first_port}" and sport <= "${last_port}" )")
+
+  # getting a port
+   num_port=$(echo "${connections}" | cut -d: -f4 | cut -d' ' -f1)
+
+  # check if we displayed information about this port
+  if ! [[ "${ports[@]}" =~ "${num_port}" ]]; then
+
+    # if the connection is new, print to stdout and add the port to the arraylast_port
+    echo "New connection on port ${connections}" | awk '{print $4, $5, $6, $7}' | tee /dev/pts/*
+
+    ports+="${num_port}"
+  else
+    echo "No listening TCP sockets bound to ports in the range 10000-10100" | tee /dev/pts/*
+  fi
+  sleep "${time_sleep}";
+
+done
+


### PR DESCRIPTION
# Summary

## Test Task

### t9 - display new tcp listening connections in the range 10000-10100 into **terminator** zsh

The solution should always output in the open terminator console even if you close and reopen the terminator window.

**name the file:** `chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh`

no args to the shell script. So you run this script. Close the shell/terminator in which you ran this script.
Open another terminator/shell (and you don't run another instance of `chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh`), run new nginx in a desired port range and immediately get that single line displayed in that new terminator/shell window. 

## my results

```
 sudo ./chapter2-l4-t9-get-tcp-listening-connections-in-terminator.sh
```

**output**:
after running the script in the second terminal, the output immediately appears

![Screenshot_20230430_210917](https://user-images.githubusercontent.com/117597862/235363808-a360e7b6-94bf-4a6d-a924-771d6f992530.png)

when opening a new terminal, we also get the output

![Screenshot_20230430_211018](https://user-images.githubusercontent.com/117597862/235363850-58fcc0f6-a6e8-45fb-a550-788295fbc911.png)
